### PR TITLE
Add new MIME type for gnome-mobi-thumbnailer

### DIFF
--- a/gnome-mobi-thumbnailer.thumbnailer.in
+++ b/gnome-mobi-thumbnailer.thumbnailer.in
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=@bindir@/gnome-mobi-thumbnailer
 Exec=@bindir@/gnome-mobi-thumbnailer -s %s %u %o
-MimeType=application/x-mobipocket-ebook;
+MimeType=application/x-mobipocket-ebook;application/x-mobi8-ebook;


### PR DESCRIPTION
This allows the gnome-mobi-thumbnailer to generate thumbnails for .azw3 files. Fedora 22, at least, distinguishes between .mobi/.azw (as application/x-mobipocket-ebook) and .azw3 (as application/x-mobi8-ebook).
